### PR TITLE
Potential fix for code scanning alert no. 20: Use of insecure SSL/TLS version

### DIFF
--- a/tests/attack/test_mod_ssl.py
+++ b/tests/attack/test_mod_ssl.py
@@ -31,6 +31,7 @@ def https_server(cert_directory: str):
 
     # Create an SSL context
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.load_cert_chain(
         certfile=os.path.join(cert_directory, "cert.pem"),
         keyfile=os.path.join(cert_directory, "key.pem")


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/20](https://github.com/deadjdona/wapiti33/security/code-scanning/20)

To fix the issue, we will explicitly enforce a minimum TLS version of 1.2 for the `ssl.SSLContext` object. This can be achieved by setting the `minimum_version` attribute of the `ssl.SSLContext` object to `ssl.TLSVersion.TLSv1_2`. This ensures that only secure versions of TLS (1.2 and above) are allowed, regardless of the system's default configuration.

The changes will be made in the `https_server` function, where the `ssl.SSLContext` object is created. We will add a line to set the `minimum_version` attribute after the context is initialized.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
