### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,15 @@
 
 name: Main Workflow
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   code_style:
     name: Code Style Analysis
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -25,6 +29,8 @@ jobs:
 
   docker:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker
@@ -38,6 +44,9 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       matrix:
         python-version: ["3.12", "3.13"]
@@ -66,6 +75,8 @@ jobs:
 
   integrate:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/21](https://github.com/deadjdona/wapiti33/security/code-scanning/21)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for each job. Based on the provided workflow, the following permissions are needed:
- `contents: read` for all jobs to allow access to the repository contents.
- `contents: write` for the `integrate` job to upload artifacts using `actions/upload-artifact`.
- `contents: read` and `security-events: write` for the `build` job to upload coverage to Codecov.

The `permissions` block will be added at the workflow level for common permissions and overridden at the job level where additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
