### PR TITLE
Potential fix for code scanning alert no. 17: Use of insecure SSL/TLS version

### DIFF
--- a/wapitiCore/attack/mod_ssl.py
+++ b/wapitiCore/attack/mod_ssl.py
@@ -75,6 +75,7 @@ def check_ev_certificate(cert: x509.Certificate) -> bool:
 
 def get_certificate(hostname: str, port: int = 443) -> x509.Certificate:
     context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
     conn = context.wrap_socket(


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/17](https://github.com/deadjdona/wapiti33/security/code-scanning/17)

To fix the issue, we will explicitly set the minimum protocol version for the SSL context to `TLSv1.2` using the `context.minimum_version` attribute. This ensures that only secure protocols are used, regardless of the Python version or system configuration. The change will be made in the `get_certificate` function, where the SSL context is created.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
