### PR TITLE
Potential fix for code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/tests/data/spip/ajaxCallback.js
+++ b/tests/data/spip/ajaxCallback.js
@@ -111,7 +111,7 @@ jQuery.fn.formulaire_dyn_ajax = function(target) {
 	if (this.length)
 		initReaderBuffer();
   return this.each(function() {
-	var cible = target || this;
+	var cible = (typeof target === 'string' && jQuery(target).length) ? target : this;
 		jQuery('form:not(.noajax)', this).each(function(){
 		var leform = this;
 		jQuery(this).prepend("<input type='hidden' name='var_ajax' value='form' />")


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/15](https://github.com/deadjdona/wapiti33/security/code-scanning/15)

To fix the issue, we need to ensure that the `target` parameter is sanitized or validated before being used in the jQuery selector. This can be achieved by:
1. Validating that `target` is a valid CSS selector or DOM element.
2. Rejecting or escaping any input that could lead to XSS vulnerabilities.

The best approach is to validate `target` and ensure it is either a DOM element or a safe CSS selector. If `target` is invalid, we should either throw an error or use a default safe value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
