### PR TITLE
Potential fix for code scanning alert no. 25: Unsafe jQuery plugin

### DIFF
--- a/tests/data/spip/ajaxCallback.js
+++ b/tests/data/spip/ajaxCallback.js
@@ -111,7 +111,7 @@ jQuery.fn.formulaire_dyn_ajax = function(target) {
 	if (this.length)
 		initReaderBuffer();
   return this.each(function() {
-	var cible = (typeof target === 'string' && jQuery(target).length) ? target : this;
+	var cible = (typeof target === 'string' && jQuery.find(target).length) ? target : this;
 		jQuery('form:not(.noajax)', this).each(function(){
 		var leform = this;
 		jQuery(this).prepend("<input type='hidden' name='var_ajax' value='form' />")


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/25](https://github.com/deadjdona/wapiti33/security/code-scanning/25)

To fix the issue, the `target` parameter should be validated to ensure it is a valid CSS selector and not interpreted as HTML. This can be achieved by using `jQuery.find` instead of `jQuery(target)`. The `find` method ensures that the input is treated as a CSS selector and does not evaluate it as HTML.

The changes will be made in the `formulaire_dyn_ajax` function in the file `tests/data/spip/ajaxCallback.js`. Specifically, the call to `jQuery(target)` on line 114 will be replaced with `jQuery.find(target)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
