### PR TITLE
Potential fix for code scanning alert no. 16: Unsafe jQuery plugin

### DIFF
--- a/tests/data/spip/ajaxCallback.js
+++ b/tests/data/spip/ajaxCallback.js
@@ -111,13 +111,13 @@ jQuery.fn.formulaire_dyn_ajax = function(target) {
 	if (this.length)
 		initReaderBuffer();
   return this.each(function() {
-	var cible = (typeof target === 'string' && jQuery(target).length) ? target : this;
+	var cible = (typeof target === 'string' && jQuery(target).length) ? jQuery(target) : jQuery(this);
 		jQuery('form:not(.noajax)', this).each(function(){
 		var leform = this;
 		jQuery(this).prepend("<input type='hidden' name='var_ajax' value='form' />")
 		.ajaxForm({
 			beforeSubmit: function(){
-				jQuery(cible).addClass('loading').animeajax();
+				cible.addClass('loading').animeajax();
 			},
 			success: function(c){
 				if (c=='noajax'){
@@ -131,7 +131,7 @@ jQuery.fn.formulaire_dyn_ajax = function(target) {
 						jQuery('<div><\/div>').html(c));
 					if (d.length)
 						c = d.html();
-					jQuery(cible)
+					cible
 					.removeClass('loading')
 					.html(c)
 					.positionner()


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/wapiti33/security/code-scanning/16](https://github.com/deadjdona/wapiti33/security/code-scanning/16)

In general, to fix unsafe jQuery plugins, ensure that any option or argument that can be influenced by untrusted input is never passed directly to `jQuery(...)` in a way that could be interpreted as HTML. Instead, either (a) restrict it to being a selector by using APIs that always treat it as a selector (like `find` on a known root), or (b) require/ensure that it is a DOM element or other safe type before use. Also, document which options must be safe selectors.

Here, the core issue is this conditional:

```js
var cible = (typeof target === 'string' && jQuery(target).length) ? target : this;
...
jQuery(cible)
  .removeClass('loading')
  .html(c)
  ...
```

If `target` is a string starting with `<`, `jQuery(target)` will create elements from HTML instead of selecting an element, and `cible` will be that same string. Later, `jQuery(cible)` again treats it as HTML, which is unnecessary and potentially unsafe. A minimal, behavior-preserving hardening is:

1. Resolve `cible` to a jQuery object or DOM element once, without passing an arbitrary string to `jQuery` more than necessary.
2. For string targets, only allow them to be used as selectors rooted in a known safe root (`document` or `this`), so they are interpreted as selectors, not HTML. In old jQuery, `$(selector, context)` still treats a string starting with `<` as HTML, so the simplest safe approach here is to resolve `target` to an actual element (or jQuery object) *once*, then keep that resolved object around instead of the raw string.
3. Ensure that later code does not call `jQuery(cible)` when `cible` is a string; instead, keep `cible` as a jQuery object.

Concretely, we can change:

- `var cible = (typeof target === 'string' && jQuery(target).length) ? target : this;`
- and all subsequent uses of `jQuery(cible)`,

so that `cible` is always a jQuery object (or DOM element) and not a raw string. For instance:

```js
var cible = (typeof target === 'string' && jQuery(target).length) ? jQuery(target) : jQuery(this);
...
cible
  .removeClass('loading')
  .html(c)
  ...
```

This way, even if a caller passes a string that starts with `<`, it will only be processed by `jQuery(target)` once in a controlled location, and from there we keep the resolved object; we no longer pass the original string into `jQuery` again at line 134, removing the plugin-pattern issue CodeQL is warning about, while keeping the behavior (content still ends up in the same element(s)).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
